### PR TITLE
hotfix: main.go not runnable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ check-fmt-solidity:
 # Golang
 .PHONY: run-go
 run-go:
-	@cd src/go && go run main.go && cd ../../
+	@go run ./src/go/...
 
 build-go:
 	go build ./src/go


### PR DESCRIPTION
## Before

```
make run-go
# command-line-arguments
src/go/main.go:83:38: undefined: server
make: *** [run-go] Error 1
```

## After

```
make run-go
2024/09/06 20:45:44 warning: TA_STORE_CONTRACT_ADDRESS is not set
2024/09/06 20:45:44 warning: PRIVATE_KEY is not set
2024/09/06 20:45:44 error: TA_STORE_CONTRACT_ADDRESS is not set
exit status 1
make: *** [run-go] Error 1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the Go application execution process to allow running multiple Go files simultaneously from the `src/go` directory.
	- Improved flexibility and usability for users running Go applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->