### PR TITLE
Reduce callback function

### DIFF
--- a/src/solidity/TransferableAccountStore.sol
+++ b/src/solidity/TransferableAccountStore.sol
@@ -211,36 +211,21 @@ contract TransferableAccountStore is Suapp, ITransferableAccountStore {
      * @param to The address to transfer the account to
      * @param accountId The account ID
      */
-    function transferAccountCallback(
+    function transferAccount(
         SignatureVerifier.TimedSignature calldata timedSignature,
         string memory accountId,
         address to
     ) public onlyLocked(accountId) {
-        require(_verifyTimedSignature(timedSignature), "Invalid timedSignature");
+        if (!verifyTimedSignature(timedSignature)) {
+            revert InvalidTimedSignature();
+        }
         require(isApproved(accountId, timedSignature.signer), "the signer is not approved");
         Account storage account = accountsStore[accountId];
         account.owner = to;
 
         // Reset approved addresses
         delete accountApprovals[account.accountId];
-
         emit AccountTransferred(accountId, account);
-    }
-
-    /**
-     * @dev Transfer an account to another address
-     * @param to The address to transfer the account to
-     * @param accountId The account ID
-     * @return bytes The encoded callback data
-     */
-    function transferAccount(
-        SignatureVerifier.TimedSignature calldata timedSignature,
-        string memory accountId,
-        address to
-    ) public view onlyLocked(accountId) returns (bytes memory) {
-        require(_verifyTimedSignature(timedSignature), "Invalid timedSignature");
-        require(isApproved(accountId, timedSignature.signer), "the signer is not approved");
-        return abi.encodePacked(this.transferAccountCallback.selector, abi.encode(timedSignature, accountId, to));
     }
 
     /**

--- a/src/solidity/TransferableAccountStore.sol
+++ b/src/solidity/TransferableAccountStore.sol
@@ -245,30 +245,17 @@ contract TransferableAccountStore is Suapp, ITransferableAccountStore {
      * @dev Unlock an account
      * @param accountId The account ID
      */
-    function unlockAccountCallback(SignatureVerifier.TimedSignature calldata timedSignature, string memory accountId)
+    function unlockAccount(SignatureVerifier.TimedSignature calldata timedSignature, string memory accountId)
         public
         onlyLocked(accountId)
     {
-        require(_verifyTimedSignature(timedSignature), "Invalid timedSignature");
+        if (!verifyTimedSignature(timedSignature)) {
+            revert InvalidTimedSignature();
+        }
         require(isOwner(accountId, timedSignature.signer), "The signer is not the owner of the account.");
         Account storage account = accountsStore[accountId];
         account.isLocked = false;
         emit AccountUnlocked(accountId);
-    }
-
-    /**
-     * @dev Unlock an account
-     * @param accountId The account ID
-     * @return bytes The encoded callback data
-     */
-    function unlockAccount(SignatureVerifier.TimedSignature calldata timedSignature, string memory accountId)
-        public
-        view
-        onlyLocked(accountId)
-        returns (bytes memory)
-    {
-        require(_verifyTimedSignature(timedSignature), "Invalid timedSignature");
-        return abi.encodePacked(this.unlockAccountCallback.selector, abi.encode(timedSignature, accountId));
     }
 
     function signCallback() public emitOffchainLogs {}

--- a/src/solidity/TransferableAccountStore.sol
+++ b/src/solidity/TransferableAccountStore.sol
@@ -232,28 +232,13 @@ contract TransferableAccountStore is Suapp, ITransferableAccountStore {
      * @dev Delete an account
      * @param accountId The account ID
      */
-    function deleteAccountCallback(SignatureVerifier.TimedSignature calldata timedSignature, string memory accountId)
-        public
-    {
-        require(_verifyTimedSignature(timedSignature), "Invalid timedSignature");
+    function deleteAccount(SignatureVerifier.TimedSignature calldata timedSignature, string memory accountId) public {
+        if (!verifyTimedSignature(timedSignature)) {
+            revert InvalidTimedSignature();
+        }
         require(isOwner(accountId, timedSignature.signer), "The signer is not the owner of the account.");
         delete accountsStore[accountId];
         emit AccountDeleted(accountId);
-    }
-
-    /**
-     * @dev Delete an account
-     * @param accountId The account ID
-     * @return bytes The encoded callback data
-     */
-    function deleteAccount(SignatureVerifier.TimedSignature calldata timedSignature, string memory accountId)
-        public
-        view
-        returns (bytes memory)
-    {
-        require(_verifyTimedSignature(timedSignature), "Invalid timedSignature");
-        require(isOwner(accountId, timedSignature.signer), "The signer is not the owner of the account.");
-        return abi.encodePacked(this.deleteAccountCallback.selector, abi.encode(timedSignature, accountId));
     }
 
     /**

--- a/src/solidity/TransferableAccountStore.sol
+++ b/src/solidity/TransferableAccountStore.sol
@@ -165,7 +165,9 @@ contract TransferableAccountStore is Suapp, ITransferableAccountStore {
         emitOffchainLogs
         returns (string memory)
     {
-        require(_verifyTimedSignature(timedSignature), "Invalid timedSignature");
+        if (!verifyTimedSignature(timedSignature)) {
+            revert InvalidTimedSignature();
+        }
         require(timedSignature.signer == account.owner, "The signer is not the owner of the account.");
         require(account.isLocked == true, "The account should be locked by default");
         string memory accountId = storeAccount(account);
@@ -181,7 +183,9 @@ contract TransferableAccountStore is Suapp, ITransferableAccountStore {
         confidential
         returns (bytes memory)
     {
-        require(_verifyTimedSignature(timedSignature), "Invalid timedSignature");
+        if (!verifyTimedSignature(timedSignature)) {
+            revert InvalidTimedSignature();
+        }
 
         string memory keyData = Suave.privateKeyGen(Suave.CryptoSignature.SECP256);
 
@@ -272,7 +276,9 @@ contract TransferableAccountStore is Suapp, ITransferableAccountStore {
         onlyUnlocked(Utils.iToHex(abi.encodePacked(accountId)))
         returns (bytes memory)
     {
-        require(_verifyTimedSignature(timedSignature), "Invalid timedSignature");
+        if (!verifyTimedSignature(timedSignature)) {
+            revert InvalidTimedSignature();
+        }
         require(isApproved(accountId, timedSignature.signer), "The signer is not approved");
 
         Account storage account = accountsStore[accountId];

--- a/src/solidity/interfaces/ITransferableAccountStore.sol
+++ b/src/solidity/interfaces/ITransferableAccountStore.sol
@@ -39,8 +39,7 @@ interface ITransferableAccountStore {
     // Actions
     function createAccount(SignatureVerifier.TimedSignature calldata signature) external returns (bytes memory);
     function transferAccount(SignatureVerifier.TimedSignature calldata signature, string memory accountId, address to)
-        external
-        returns (bytes memory);
+        external;
     function deleteAccount(SignatureVerifier.TimedSignature calldata signature, string memory accountId)
         external
         returns (bytes memory);

--- a/src/solidity/interfaces/ITransferableAccountStore.sol
+++ b/src/solidity/interfaces/ITransferableAccountStore.sol
@@ -51,7 +51,7 @@ interface ITransferableAccountStore {
         SignatureVerifier.TimedSignature calldata signature,
         string memory accountId,
         address _address
-    ) external returns (bytes memory);
+    ) external;
     function revokeApproval(
         SignatureVerifier.TimedSignature calldata signature,
         string memory accountId,

--- a/src/solidity/interfaces/ITransferableAccountStore.sol
+++ b/src/solidity/interfaces/ITransferableAccountStore.sol
@@ -40,9 +40,7 @@ interface ITransferableAccountStore {
     function createAccount(SignatureVerifier.TimedSignature calldata signature) external returns (bytes memory);
     function transferAccount(SignatureVerifier.TimedSignature calldata signature, string memory accountId, address to)
         external;
-    function deleteAccount(SignatureVerifier.TimedSignature calldata signature, string memory accountId)
-        external
-        returns (bytes memory);
+    function deleteAccount(SignatureVerifier.TimedSignature calldata signature, string memory accountId) external;
     function unlockAccount(SignatureVerifier.TimedSignature calldata signature, string memory accountId)
         external
         returns (bytes memory);

--- a/src/solidity/interfaces/ITransferableAccountStore.sol
+++ b/src/solidity/interfaces/ITransferableAccountStore.sol
@@ -56,7 +56,7 @@ interface ITransferableAccountStore {
         SignatureVerifier.TimedSignature calldata signature,
         string memory accountId,
         address _address
-    ) external returns (bytes memory);
+    ) external;
 
     function sign(SignatureVerifier.TimedSignature calldata timedSignature, string memory accountId, bytes memory data)
         external

--- a/src/solidity/interfaces/ITransferableAccountStore.sol
+++ b/src/solidity/interfaces/ITransferableAccountStore.sol
@@ -41,9 +41,7 @@ interface ITransferableAccountStore {
     function transferAccount(SignatureVerifier.TimedSignature calldata signature, string memory accountId, address to)
         external;
     function deleteAccount(SignatureVerifier.TimedSignature calldata signature, string memory accountId) external;
-    function unlockAccount(SignatureVerifier.TimedSignature calldata signature, string memory accountId)
-        external
-        returns (bytes memory);
+    function unlockAccount(SignatureVerifier.TimedSignature calldata signature, string memory accountId) external;
     function approveAddress(
         SignatureVerifier.TimedSignature calldata signature,
         string memory accountId,

--- a/test/TransferableAccountStore.t.sol
+++ b/test/TransferableAccountStore.t.sol
@@ -215,7 +215,7 @@ contract TransferableAccountStoreTest is Test, SuaveEnabled {
         bool isApproved = tas.isApproved(accountId, bob);
         assertTrue(isApproved, "Address should be approved");
 
-        tas.revokeApprovalCallback(sig, accountId, bob);
+        tas.revokeApproval(sig, accountId, bob);
         isApproved = tas.isApproved(accountId, bob);
         assertFalse(isApproved, "Address should not be approved after revocation");
     }
@@ -269,45 +269,10 @@ contract TransferableAccountStoreTest is Test, SuaveEnabled {
         string memory accountId = tas.createAccountCallback(sig, account);
         tas.approveAddress(sig, accountId, bob);
 
-        bytes memory encodedRevokeApprovalData = tas.revokeApproval(sig, accountId, bob);
-        bytes memory revokeApprovalData = decodeEncodedData(encodedRevokeApprovalData);
-
-        (
-            SignatureVerifier.TimedSignature memory decodedTimedSignature,
-            string memory decodedRevokeAccountId,
-            address decodedRevokeAddress
-        ) = abi.decode(revokeApprovalData, (SignatureVerifier.TimedSignature, string, address));
-
-        assertEq(decodedTimedSignature.signature, sig.signature, "Signature should be same");
-        assertEq(decodedRevokeAccountId, accountId, "Approved account ID should match");
-        assertEq(decodedRevokeAddress, bob, "Approved account address should match");
-    }
-
-    function testRevokeApprovalCallback() public {
-        (TransferableAccountStore tas, SignatureVerifier.TimedSignature memory sig) =
-            setupTransferableAccountStore(uint64(block.timestamp + 86400), alice, alicePrivateKey);
-        bytes memory encodedCreateAccountData = tas.createAccount(sig);
-        bytes memory accountData = decodeEncodedData(encodedCreateAccountData);
-
-        (, ITransferableAccountStore.Account memory account) =
-            abi.decode(accountData, (SignatureVerifier.TimedSignature, ITransferableAccountStore.Account));
-
-        string memory accountId = tas.createAccountCallback(sig, account);
-        tas.approveAddress(sig, accountId, bob);
-
-        bytes memory encodedRevokeApprovalData = tas.revokeApproval(sig, accountId, bob);
-        bytes memory revokeApprovalData = decodeEncodedData(encodedRevokeApprovalData);
-
-        (
-            SignatureVerifier.TimedSignature memory decodedTimedSignature,
-            string memory decodedRevokeAccountId,
-            address decodedRevokeAddress
-        ) = abi.decode(revokeApprovalData, (SignatureVerifier.TimedSignature, string, address));
-
         bool isApproved = tas.isApproved(accountId, bob);
         assertTrue(isApproved, "Address should be approved");
 
-        tas.revokeApprovalCallback(decodedTimedSignature, decodedRevokeAccountId, decodedRevokeAddress);
+        tas.revokeApproval(sig, accountId, bob);
 
         isApproved = tas.isApproved(accountId, bob);
         assertFalse(isApproved, "Address should not be approved after revocation");

--- a/test/TransferableAccountStore.t.sol
+++ b/test/TransferableAccountStore.t.sol
@@ -154,47 +154,9 @@ contract TransferableAccountStoreTest is Test, SuaveEnabled {
         SignatureVerifier.TimedSignature memory bobSig =
             generateTimedSignature(uint64(block.timestamp + 86400), bob, bobPrivateKey);
 
-        bytes memory encodedTransferAccountData = tas.transferAccount(bobSig, accountId, bob);
-        bytes memory transferAccountData = decodeEncodedData(encodedTransferAccountData);
+        tas.transferAccount(bobSig, accountId, bob);
 
-        (
-            SignatureVerifier.TimedSignature memory decodedTimedSignature,
-            string memory decodedTransferdAccountId,
-            address decodedToAddress
-        ) = abi.decode(transferAccountData, (SignatureVerifier.TimedSignature, string, address));
-
-        assertEq(decodedTimedSignature.signature, bobSig.signature, "Signature should be same");
-        assertEq(decodedTransferdAccountId, accountId, "Approved account ID should match");
-        assertEq(decodedToAddress, bob, "Approved account address should match");
-    }
-
-    function testTransferAccountCallback() public {
-        (TransferableAccountStore tas, SignatureVerifier.TimedSignature memory aliceSig) =
-            setupTransferableAccountStore(uint64(block.timestamp + 86400), alice, alicePrivateKey);
-        bytes memory encodedCreateAccountData = tas.createAccount(aliceSig);
-        bytes memory accountData = decodeEncodedData(encodedCreateAccountData);
-
-        (, ITransferableAccountStore.Account memory account) =
-            abi.decode(accountData, (SignatureVerifier.TimedSignature, ITransferableAccountStore.Account));
-
-        string memory accountId = tas.createAccountCallback(aliceSig, account);
-        tas.approveAddress(aliceSig, accountId, bob);
-
-        SignatureVerifier.TimedSignature memory bobSig =
-            generateTimedSignature(uint64(block.timestamp + 86400), bob, bobPrivateKey);
-
-        bytes memory encodedTransferAccountData = tas.transferAccount(bobSig, accountId, bob);
-        bytes memory transferAccountData = decodeEncodedData(encodedTransferAccountData);
-
-        (
-            SignatureVerifier.TimedSignature memory decodedTimedSignature,
-            string memory decodedTransferdAccountId,
-            address decodedToAddress
-        ) = abi.decode(transferAccountData, (SignatureVerifier.TimedSignature, string, address));
-
-        tas.transferAccountCallback(decodedTimedSignature, decodedTransferdAccountId, decodedToAddress);
-
-        (, address newOwner,,,, bool isAccountLocked) = tas.accountsStore(decodedTransferdAccountId);
+        (, address newOwner,,,, bool isAccountLocked) = tas.accountsStore(accountId);
 
         assertEq(newOwner, bob, "Stored account owner should match");
         assertTrue(isAccountLocked, "Transfered account should be locked");

--- a/test/TransferableAccountStore.t.sol
+++ b/test/TransferableAccountStore.t.sol
@@ -259,7 +259,7 @@ contract TransferableAccountStoreTest is Test, SuaveEnabled {
         assertEq(retrievedAccount.owner, address(0), "Owner should be zero address after deletion");
     }
 
-    function testUnlockAccountCallback() public {
+    function testUnlockAccount() public {
         (TransferableAccountStore tas, SignatureVerifier.TimedSignature memory sig) =
             setupTransferableAccountStore(uint64(block.timestamp + 86400), alice, alicePrivateKey);
         bytes memory encodedCreateAccountData = tas.createAccount(sig);
@@ -272,12 +272,7 @@ contract TransferableAccountStoreTest is Test, SuaveEnabled {
         bool isAccountLocked = tas.isAccountLocked(accountId);
         assertTrue(isAccountLocked, "Account should be locked immediately after creation");
 
-        bytes memory encodedUnlockAccountData = tas.unlockAccount(sig, accountId);
-        bytes memory unlockAccountData = decodeEncodedData(encodedUnlockAccountData);
-
-        (SignatureVerifier.TimedSignature memory decodedTimedSignature, string memory decodedAccountId) =
-            abi.decode(unlockAccountData, (SignatureVerifier.TimedSignature, string));
-        tas.unlockAccountCallback(decodedTimedSignature, decodedAccountId);
+        tas.unlockAccount(sig, accountId);
 
         isAccountLocked = tas.isAccountLocked(accountId);
         assertFalse(isAccountLocked, "Account should be unlocked");
@@ -296,12 +291,7 @@ contract TransferableAccountStoreTest is Test, SuaveEnabled {
         bool isAccountLocked = tas.isAccountLocked(accountId);
         assertTrue(isAccountLocked, "Account should be locked immediately after creation");
 
-        bytes memory encodedUnlockAccountData = tas.unlockAccount(sig, accountId);
-        bytes memory unlockAccountData = decodeEncodedData(encodedUnlockAccountData);
-
-        (SignatureVerifier.TimedSignature memory decodedTimedSignature, string memory decodedAccountId) =
-            abi.decode(unlockAccountData, (SignatureVerifier.TimedSignature, string));
-        tas.unlockAccountCallback(decodedTimedSignature, decodedAccountId);
+        tas.unlockAccount(sig, accountId);
 
         isAccountLocked = tas.isAccountLocked(accountId);
 

--- a/test/TransferableAccountStore.t.sol
+++ b/test/TransferableAccountStore.t.sol
@@ -133,44 +133,10 @@ contract TransferableAccountStoreTest is Test, SuaveEnabled {
             abi.decode(accountData, (SignatureVerifier.TimedSignature, ITransferableAccountStore.Account));
 
         string memory accountId = tas.createAccountCallback(sig, decodedAccount);
-        bytes memory encodedApproveAddressData = tas.approveAddress(sig, accountId, bob);
-        bytes memory approveAddressData = decodeEncodedData(encodedApproveAddressData);
+        tas.approveAddress(sig, accountId, bob);
 
-        (
-            SignatureVerifier.TimedSignature memory decodedTimedSignature,
-            bytes16 decodedAccountId,
-            address decodedAddress
-        ) = abi.decode(approveAddressData, (SignatureVerifier.TimedSignature, bytes16, address));
-
-        assertEq(decodedTimedSignature.signature, sig.signature, "Signature should be same");
-        assertEq(StringUtils.bytes16ToString(decodedAccountId), accountId, "Approved account ID should match");
-        assertEq(decodedAddress, bob, "Approved account address should match");
-    }
-
-    function testApproveAddressCallback() public {
-        (TransferableAccountStore tas, SignatureVerifier.TimedSignature memory sig) =
-            setupTransferableAccountStore(uint64(block.timestamp + 86400), alice, alicePrivateKey);
-        bytes memory encodedCreateAccountData = tas.createAccount(sig);
-        bytes memory accountData = decodeEncodedData(encodedCreateAccountData);
-
-        (, ITransferableAccountStore.Account memory decodedAccount) =
-            abi.decode(accountData, (SignatureVerifier.TimedSignature, ITransferableAccountStore.Account));
-
-        string memory accountId = tas.createAccountCallback(sig, decodedAccount);
-        bytes memory encodedApproveAddressData = tas.approveAddress(sig, accountId, bob);
-        bytes memory approveAddressData = decodeEncodedData(encodedApproveAddressData);
-
-        (
-            SignatureVerifier.TimedSignature memory decodedTimedSignature,
-            bytes16 decodedAccountId,
-            address decodedAddress
-        ) = abi.decode(approveAddressData, (SignatureVerifier.TimedSignature, bytes16, address));
-        tas.approveAddressCallback(decodedTimedSignature, Suave.DataId.wrap(decodedAccountId), decodedAddress);
-
-        assertEq(decodedAddress, bob, "Approved account address should match");
-
-        address approvedAddress = tas.accountApprovals(Suave.DataId.wrap(decodedAccountId));
-        assertEq(approvedAddress, decodedAddress, "Approved account address should match");
+        address approvedAddress = tas.accountApprovals(decodedAccount.accountId);
+        assertEq(bob, approvedAddress, "Approved account address should match");
     }
 
     function testTransferAccount() public {
@@ -183,12 +149,7 @@ contract TransferableAccountStoreTest is Test, SuaveEnabled {
             abi.decode(accountData, (SignatureVerifier.TimedSignature, ITransferableAccountStore.Account));
 
         string memory accountId = tas.createAccountCallback(aliceSig, account);
-        bytes memory encodedApproveAddressData = tas.approveAddress(aliceSig, accountId, bob);
-        bytes memory approveAddressData = decodeEncodedData(encodedApproveAddressData);
-
-        (, bytes16 decodedAccountId, address decodedAddress) =
-            abi.decode(approveAddressData, (SignatureVerifier.TimedSignature, bytes16, address));
-        tas.approveAddressCallback(aliceSig, Suave.DataId.wrap(decodedAccountId), decodedAddress);
+        tas.approveAddress(aliceSig, accountId, bob);
 
         SignatureVerifier.TimedSignature memory bobSig =
             generateTimedSignature(uint64(block.timestamp + 86400), bob, bobPrivateKey);
@@ -217,12 +178,7 @@ contract TransferableAccountStoreTest is Test, SuaveEnabled {
             abi.decode(accountData, (SignatureVerifier.TimedSignature, ITransferableAccountStore.Account));
 
         string memory accountId = tas.createAccountCallback(aliceSig, account);
-        bytes memory encodedApproveAddressData = tas.approveAddress(aliceSig, accountId, bob);
-        bytes memory approveAddressData = decodeEncodedData(encodedApproveAddressData);
-
-        (, bytes16 decodedAccountId, address decodedAddress) =
-            abi.decode(approveAddressData, (SignatureVerifier.TimedSignature, bytes16, address));
-        tas.approveAddressCallback(aliceSig, Suave.DataId.wrap(decodedAccountId), decodedAddress);
+        tas.approveAddress(aliceSig, accountId, bob);
 
         SignatureVerifier.TimedSignature memory bobSig =
             generateTimedSignature(uint64(block.timestamp + 86400), bob, bobPrivateKey);
@@ -254,15 +210,7 @@ contract TransferableAccountStoreTest is Test, SuaveEnabled {
             abi.decode(accountData, (SignatureVerifier.TimedSignature, ITransferableAccountStore.Account));
 
         string memory accountId = tas.createAccountCallback(sig, account);
-        bytes memory encodedApproveAddressData = tas.approveAddress(sig, accountId, bob);
-        bytes memory approveAddressData = decodeEncodedData(encodedApproveAddressData);
-
-        (
-            SignatureVerifier.TimedSignature memory decodedTimedSignature,
-            bytes16 decodedAccountId,
-            address decodedAddress
-        ) = abi.decode(approveAddressData, (SignatureVerifier.TimedSignature, bytes16, address));
-        tas.approveAddressCallback(decodedTimedSignature, Suave.DataId.wrap(decodedAccountId), decodedAddress);
+        tas.approveAddress(sig, accountId, bob);
 
         bool isApproved = tas.isApproved(accountId, bob);
         assertTrue(isApproved, "Address should be approved");
@@ -319,12 +267,7 @@ contract TransferableAccountStoreTest is Test, SuaveEnabled {
             abi.decode(accountData, (SignatureVerifier.TimedSignature, ITransferableAccountStore.Account));
 
         string memory accountId = tas.createAccountCallback(sig, account);
-        bytes memory encodedApproveAddressData = tas.approveAddress(sig, accountId, bob);
-        bytes memory approveAddressData = decodeEncodedData(encodedApproveAddressData);
-
-        (, bytes16 decodedAccountId, address decodedAddress) =
-            abi.decode(approveAddressData, (SignatureVerifier.TimedSignature, bytes16, address));
-        tas.approveAddressCallback(sig, Suave.DataId.wrap(decodedAccountId), decodedAddress);
+        tas.approveAddress(sig, accountId, bob);
 
         bytes memory encodedRevokeApprovalData = tas.revokeApproval(sig, accountId, bob);
         bytes memory revokeApprovalData = decodeEncodedData(encodedRevokeApprovalData);
@@ -350,12 +293,7 @@ contract TransferableAccountStoreTest is Test, SuaveEnabled {
             abi.decode(accountData, (SignatureVerifier.TimedSignature, ITransferableAccountStore.Account));
 
         string memory accountId = tas.createAccountCallback(sig, account);
-        bytes memory encodedApproveAddressData = tas.approveAddress(sig, accountId, bob);
-        bytes memory approveAddressData = decodeEncodedData(encodedApproveAddressData);
-
-        (, bytes16 decodedAccountId, address decodedAddress) =
-            abi.decode(approveAddressData, (SignatureVerifier.TimedSignature, bytes16, address));
-        tas.approveAddressCallback(sig, Suave.DataId.wrap(decodedAccountId), decodedAddress);
+        tas.approveAddress(sig, accountId, bob);
 
         bytes memory encodedRevokeApprovalData = tas.revokeApproval(sig, accountId, bob);
         bytes memory revokeApprovalData = decodeEncodedData(encodedRevokeApprovalData);

--- a/test/TransferableAccountStore.t.sol
+++ b/test/TransferableAccountStore.t.sol
@@ -240,7 +240,7 @@ contract TransferableAccountStoreTest is Test, SuaveEnabled {
         assertFalse(isApproved, "Address should not be approved after revocation");
     }
 
-    function testDeleteAccountCallback() public {
+    function testDeleteAccount() public {
         (TransferableAccountStore tas, SignatureVerifier.TimedSignature memory sig) =
             setupTransferableAccountStore(uint64(block.timestamp + 86400), alice, alicePrivateKey);
         bytes memory encodedCreateAccountData = tas.createAccount(sig);
@@ -253,14 +253,9 @@ contract TransferableAccountStoreTest is Test, SuaveEnabled {
         ITransferableAccountStore.Account memory retrievedAccount = tas.getAccount(accountId);
         assertEq(retrievedAccount.owner, account.owner, "Owner should match before deletion");
 
-        bytes memory encodedDeleteAccountData = tas.deleteAccount(sig, accountId);
-        bytes memory deleteAccountData = decodeEncodedData(encodedDeleteAccountData);
+        tas.deleteAccount(sig, accountId);
 
-        (SignatureVerifier.TimedSignature memory decodedTimedSignature, string memory decodedAccountId) =
-            abi.decode(deleteAccountData, (SignatureVerifier.TimedSignature, string));
-        tas.deleteAccountCallback(decodedTimedSignature, decodedAccountId);
-
-        retrievedAccount = tas.getAccount(decodedAccountId);
+        retrievedAccount = tas.getAccount(accountId);
         assertEq(retrievedAccount.owner, address(0), "Owner should be zero address after deletion");
     }
 


### PR DESCRIPTION
# What to do in this PR

- Callback functions have been removed from all functions except for createAccount and Sign.
- An error is now returned when the timedSignature is invalid.
- The issue where signing was possible while the account remained locked has been fixed.

# Why this PR is necessary
This PR is necessary to simplify the control of timedSignature by removing callback functions. This makes the logic cleaner and more maintainable, allowing better control and handling of timedSignature across the system.

## notion
After this PR is merged, please merge the PR that restricts timedSignature to be used only once.